### PR TITLE
PRKT-64 Windows Serial Port Driver

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.0.1] - 2021-06-09
+### Modified
+- Changed documentation to more clearly state the need for the UART to USB Driver.
+
 ## [1.0.0] - 2021-06-07
 ### Added
 - Visualization of data through use of the parakeet-sdk library

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required (VERSION 3.10)
-project(parakeet-qt VERSION 1.0.0 LANGUAGES CXX)
+project(parakeet-qt VERSION 1.0.1 LANGUAGES CXX)
 
 set(CMAKE_AUTOUIC ON)
 set(CMAKE_AUTOMOC ON)

--- a/README.md
+++ b/README.md
@@ -5,3 +5,7 @@ Qt application which depends on the [Parakeet-SDK](https://github.com/MechaSpin/
 Documentation for building and running the Qt application can be found [here](docs/Building%20and%20Running.md).
 
 [Windows Binaries](https://github.com/MechaSpin/parakeet-qt/releases) have been pre-built for your convience.
+
+## Windows Requirements
+
+The CP210x USB to UART Bridge connector needs a specific driver installed to be used on Windows. You can find the latest driver [here](https://www.silabs.com/developers/usb-to-uart-bridge-vcp-drivers).

--- a/docs/Building and Running.md
+++ b/docs/Building and Running.md
@@ -48,6 +48,7 @@ git clone https://github.com/MechaSpin/parakeet-qt
 - Right click the project, and select build
 
 #### 7a. Running using Visual Studio
+- Ensure that you have installed the [UART to USB Driver](https://www.silabs.com/developers/usb-to-uart-bridge-vcp-drivers)
 - Locate your Qt bin folder
 - In the solution explorer, right click on the SimpleExample project, and select properties
 - Under the debugging tab, in the Environment section, add the following, and replace MY_PATH_TO_Qt_BIN with the path found earlier
@@ -61,6 +62,7 @@ PATH=%PATH%;MY_PATH_TO_Qt_BIN
 - Click the run button
 
 #### 7b. Running using Command Prompt
+- Ensure that you have installed the [UART to USB Driver](https://www.silabs.com/developers/usb-to-uart-bridge-vcp-drivers)
 - Attempting to run the application without the correct Qt Dependencies in the same folder, will result in DLL missing issues
 - If building as a debug build: 
 	- Move the following DLLs into the {PARAKEET_QT_ROOT}/build/Debug folder:


### PR DESCRIPTION
Modify the documentation to more clearly state the need for the UART to USB Driver on Windows.