### PR TITLE
PRKT-86 Lower CMake Version to 3.5

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required (VERSION 3.10)
+cmake_minimum_required (VERSION 3.5)
 project(parakeet-qt VERSION 1.0.2 LANGUAGES CXX)
 
 set(CMAKE_AUTOUIC ON)


### PR DESCRIPTION
Ubuntu Xenial has CMake 3.5 as it's default version. Therefore, we are switching to help support Xenial out of the box.